### PR TITLE
Add NTK-Aware interpolation "by parts" correction

### DIFF
--- a/scaled_rope/LlamaPartNTKScaledRotaryEmbedding.py
+++ b/scaled_rope/LlamaPartNTKScaledRotaryEmbedding.py
@@ -1,0 +1,78 @@
+import torch
+import math
+
+def find_correction_factor(num_rotations, dim, base=10000, max_position_embeddings=2048):
+    return (dim * math.log(max_position_embeddings/(num_rotations * 2 * math.pi)))/(2 * math.log(base)) #Inverse dim formula to find number of rotations
+
+def find_correction_range(low_rot, high_rot, dim, base=10000, max_position_embeddings=2048):
+    low = math.floor(find_correction_factor(low_rot, dim, base, max_position_embeddings))
+    high = math.ceil(find_correction_factor(high_rot, dim, base, max_position_embeddings))
+    return max(low, 0), min(high, dim-1) #Clamp values just in case
+
+def linear_ramp_mask(min, max, dim):
+    if min == max:
+        max += 0.001 #Prevent singularity
+
+    linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+    ramp_func = torch.clamp(linear_func, 0, 1)
+    return ramp_func
+
+def find_newbase_ntk(dim, base=10000, scale=1):
+    return base * scale ** (dim / (dim-2))
+
+class LlamaPartNTKScaledRotaryEmbedding(torch.nn.Module):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, scale=1, ntk_factor=1, extrapolation_factor=1, device=None):
+        super().__init__()
+        
+        #Interpolation constants found experimentally for LLaMA (might not be totally optimal though)
+        #Do not change unless there is a good reason for doing so!
+        beta_0 = 1.25
+        beta_1 = 0.75
+        gamma_0 = 16
+        gamma_1 = 2
+
+        #Three RoPE extrapolation/interpolation methods
+        inv_freq_base = 1.0 / (base ** (torch.arange(0, dim, 2).float().to(device) / dim))
+        inv_freq_linear = 1.0 / (scale * (base ** (torch.arange(0, dim, 2).float().to(device) / dim)))
+        inv_freq_ntk = 1.0 / (find_newbase_ntk(dim, base, scale) ** (torch.arange(0, dim, 2).float().to(device) / dim))
+
+        current_dtype = inv_freq_ntk.dtype
+        current_device = inv_freq_ntk.device
+        
+        #Combine NTK and Linear
+        low, high = find_correction_range(beta_0, beta_1, dim, base, max_position_embeddings)
+        inv_freq_mask = (1 - linear_ramp_mask(low, high, dim // 2).type(current_dtype).to(current_device)) * ntk_factor
+        inv_freq = inv_freq_linear * (1 - inv_freq_mask) + inv_freq_ntk * inv_freq_mask
+    
+        #Combine Extrapolation and NTK and Linear
+        low, high = find_correction_range(gamma_0, gamma_1, dim, base, max_position_embeddings)
+        inv_freq_mask = (1 - linear_ramp_mask(low, high, dim // 2).type(current_dtype).to(current_device)) * extrapolation_factor
+        inv_freq = inv_freq * (1 - inv_freq_mask) + inv_freq_base * inv_freq_mask
+
+        self.register_buffer("inv_freq", inv_freq)
+
+        # Build here to make `torch.jit.trace` work.
+        self.max_seq_len_cached = max_position_embeddings
+        t = torch.arange(self.max_seq_len_cached, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+        # Different from paper, but it uses a different permutation in order to obtain the same calculation
+        emb = torch.cat((freqs, freqs), dim=-1)
+        dtype = torch.get_default_dtype()
+        self.register_buffer("cos_cached", emb.cos()[None, None, :, :].to(dtype), persistent=False)
+        self.register_buffer("sin_cached", emb.sin()[None, None, :, :].to(dtype), persistent=False)
+
+    def forward(self, x, seq_len=None):
+        # x: [bs, num_attention_heads, seq_len, head_size]
+        # This `if` block is unlikely to be run after we build sin/cos in `__init__`. Keep the logic here just in case.
+        if seq_len > self.max_seq_len_cached:
+            self.max_seq_len_cached = seq_len
+            t = torch.arange(self.max_seq_len_cached, device=x.device, dtype=self.inv_freq.dtype)
+            freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+            # Different from paper, but it uses a different permutation in order to obtain the same calculation
+            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+            self.register_buffer("cos_cached", emb.cos()[None, None, :, :].to(x.dtype), persistent=False)
+            self.register_buffer("sin_cached", emb.sin()[None, None, :, :].to(x.dtype), persistent=False)
+        return (
+            self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
+            self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
+        )


### PR DESCRIPTION
This PR adds the new and improved "by parts" correction to the NTK-aware interpolation method.

This corrected method improves from previous methods fourfold:

1. Decreases PPL in all context lengths when used on non-finetuned models compared to previous NTK-Aware method, especially for higher context sizes as alpha value can be set much lower for same context size.
2. Removes the alpha parameter, which did not accurately predict effective context length and was variable across different models. Now uses same scale parameter as linear interpolation which is much more intuitive and less prone to mistakes/misuse. (This was possible by fixing the alpha scale "drift" found in all LLaMA models)
3. Fixes the extrapolation regime that was breaking a lot of fine-tunes when alpha was set to a non-optimal value. Fine-tuning should be much easier and performance should in theory be increased significantly as there is no need to search for optimal alpha.
4. This method generalizes on both Extrapolation, NTK-Aware and Linear interpolation. For example, setting ntk_factor and extrapolation_factor to 0 will yield identical results to linear interpolation.

`scale` parameter should be used the same as linear interpolation. (eg. scale=2 is 2048 base ctx extended to 4096)
`extrapolation_factor` and `ntk_factor` are used for validation purposes, and should not be changed unless it is necessary.
Edit: ~~Also `max_position_embeddings` is assumed to be the original pretrained model context size! Leave it at 2048 for LLaMA models, changing it will break the code...~~ Fixed, added `original_max_position_embeddings` parameter to avoid any confusion

Comparison of new corrected NTK-Aware method to previous non-corrected NTK-Aware method. Note the new `scale` factor is still called `alpha` in this graph.
![Comparison graph](https://github.com/jquesnelle/scaled-rope/assets/567732/e738aaff-cc05-4a5c-9f3b-8c0dd353ea3e)

Now all is left is to validate this by finetuning!